### PR TITLE
Temporarily remove validator from image and use openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ COPY . /usr/src/xhtml-validator
 WORKDIR /usr/src/xhtml-validator
 RUN ./gradlew jar
 
-
-FROM ghcr.io/validator/validator:21.7.10
-COPY --from=JAVA_BUILD /usr/src/xhtml-validator/build/libs/xhtml-validator.jar /.
+RUN cp /usr/src/xhtml-validator/build/libs/xhtml-validator.jar /.
+WORKDIR /
 ENTRYPOINT ["java", "-cp", "xhtml-validator.jar", "org.openstax.xml.Main"]


### PR DESCRIPTION
The earlier fix to use the new validator/validator base image from
GitHub exposed an issue that their usage of distroless means basic
assumptions like the existence of bash are no longer valid. This is
a quick fix to just stick with the openjdk base for the time being
to unblock a pipeline deployment since validator isn't currently
used.