### PR TITLE
Support reading input from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-.gradle
-build
+/.gradle/
+/build/
+
+# Files that the VSCode XML extension creates
+/bin/
+/.project
+/.classpath
+/.settings/org.eclipse.buildship.core.prefs

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This performs the following validations:
 
 Mount a volume and specify the path to the XHTML file as the argument.
 
+When the argument is `-` then stdin is used instead of reading from a File.
+
 ```bash
 # Clone this repo and run:
 docker run --volume $(pwd):/data --rm -it $(docker build -q .) /data/test/resources/fail-duplicate.xhtml
@@ -28,6 +30,9 @@ docker run --volume $(pwd):/data --rm -it $(docker build -q .) /data/test/resour
 docker run --volume $(pwd):/data --rm -it $(docker build -q .) /data/test/resources/pass.xhtml
 
 docker run --volume $(pwd):/data --rm -it $(docker build -q .) /data/test/resources/fail-link-to-duplicate-id.xhtml link-to-duplicate-id
+
+# Verify that the magic stdin file ('-') works
+cat ./test/resources/fail-duplicate.xhtml | docker run --rm -i $(docker build -q .) -
 ```
 
 An additional optional argument specifies which test to run:

--- a/src/org/openstax/xml/Main.java
+++ b/src/org/openstax/xml/Main.java
@@ -14,10 +14,16 @@ public class Main {
         if (args.length == 0) {
             throw new RuntimeException("Requires 2 arguments: the path to a file to validate and which checks to run ('all-checks', 'duplicate-id', 'broken-link')");
         }
-        File inputFile = new File(args[0]);
+        InputStream input;
+        if ("-".equals(args[0])) {
+            // Read from stdin
+            input = System.in;
+        } else {
+            File inputFile = new File(args[0]);
+            input = new FileInputStream(inputFile);
+        }
         String[] desiredChecks = args.length == 1 ? new String[]{"all"} : Arrays.copyOfRange(args, 1, args.length);
-        FileInputStream fileInputStream = new FileInputStream(inputFile);
-        runChecks(fileInputStream, desiredChecks);
+        runChecks(input, desiredChecks);
     }
 
     public static void runChecks(InputStream inputStream, String[] desiredChecks) throws Throwable {

--- a/test/org/openstax/xml/RunnerTests.java
+++ b/test/org/openstax/xml/RunnerTests.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.PrintStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.xml.sax.SAXParseException;
 
 class RunnerTests {
     private final ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+    private final InputStream originalIn = System.in;
     private final PrintStream originalErr = System.err;
 
     @BeforeEach
@@ -20,6 +23,7 @@ class RunnerTests {
 
     @AfterEach
     public void restore() {
+        System.setIn(originalIn);
         System.setErr(originalErr);
     }
 
@@ -54,5 +58,30 @@ class RunnerTests {
         assertFalse(capturedErr.toString().contains("Links that point to nowhere"));
         assertFalse(capturedErr.toString().contains("Number of duplicate-id elements"));
         assertFalse(capturedErr.toString().contains("Found at least one link that points to multiple elements"));
+    }
+
+    @Test
+    void failsWhenDashIsProvidedButStandardInIsEmpty() {
+        assertThrows(SAXParseException.class, () -> Main.main(new String[]{"-", "all"}));
+    }
+
+    @Test
+    void useStandardInWhenDashIsProvided() {
+        // Verify we parse XML from stdin
+        InputStream inputFileStream = getClass().getClassLoader().getResourceAsStream("pass.xhtml");
+        System.setIn(inputFileStream);
+        assertDoesNotThrow(() -> Main.main(new String[]{"-", "all"}));
+    }
+
+    @Test
+    void errorWhenNoArgumentsProvided() {
+        assertThrows(RuntimeException.class, () -> Main.main(new String[]{}));
+    }
+    
+    @Test
+    void failWhenInvalidCheckIsProvided() {
+        InputStream inputFileStream = getClass().getClassLoader().getResourceAsStream("pass.xhtml");
+        System.setIn(inputFileStream);
+        assertThrows(RuntimeException.class, () -> Main.main(new String[]{"-", "invalid-check"}));
     }
 }


### PR DESCRIPTION
Java does not support unicode in commandline argument strings (`public static void main(String[] args)`).

This adds support to pipe the file contents in. Bash example:

```bash
docker run --rm $(docker build -q .) - < ./test/resources/fail-duplicate.xhtml
```